### PR TITLE
Allow fetching of specific ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.vscode/
+.idea/

--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
     'Field', 'FieldError', 'LocationField',
     'Reader', 'ReaderError', 'NotFoundError',
-    'GetByIdBasedOnQueryMixin', 'PreparedQuery', 'PreparedQueryType',
+    'GetByIdBasedOnQueryMixin', 'BasePreparedQuery', 'PreparedQueryType',
     'Record', 'RawData', 'RecordError', 'BibliographicalRecord',
     'BiographicalRecord', 'LazyRecordMixin',
     'SRUReader',
@@ -19,7 +19,7 @@ BIOGRAPHICAL = "biographical"
 from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
 from .fields import Field, FieldError, LocationField
 from .reader import (
-    Reader, ReaderError, GetByIdBasedOnQueryMixin, PreparedQuery,
+    Reader, ReaderError, GetByIdBasedOnQueryMixin, BasePreparedQuery,
     PreparedQueryType, NotFoundError
 )
 from .record import (

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -192,6 +192,7 @@ class GetByIdBasedOnQueryMixin(ABC):
         if reader.number_of_results == 0:
             raise ReaderError("No results returned")
         for record in reader.records:
+            assert record is not None
             if record.identifier == identifier:
                 return record
         # Record with correct ID was not returned in first fetch -

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -2,11 +2,10 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, List, Union, Dict
+from typing import Optional, Union, Dict
 from rdflib import Graph, RDF, URIRef
 from urllib.parse import quote, unquote
 
-from typing_extensions import override
 
 from edpop_explorer import (
     EDPOPREC, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -11,11 +11,14 @@ from .record import Record
 
 
 @dataclass
-class PreparedQuery:
+class BasePreparedQuery:
+    """Empty base dataclass for prepared queries. For prepared queries that
+    can be represented by a single string, do not inherit from this class
+    but use a simple string instead."""
     pass
 
 
-PreparedQueryType = Union[str, PreparedQuery]
+PreparedQueryType = Union[str, BasePreparedQuery]
 
 
 class Reader(ABC):

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -2,9 +2,11 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict
 from rdflib import Graph, RDF, URIRef
 from urllib.parse import quote, unquote
+
+from typing_extensions import override
 
 from edpop_explorer import (
     EDPOPREC, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces
@@ -35,93 +37,130 @@ class Reader(ABC):
     fetching.
 
     To create a concrete reader, make a subclass that implements the
-    ``fetch()``, ``fetch_next()`` and ``transform_query()`` methods
+    ``fetch_range()`` and ``transform_query()`` methods
     and set the ``READERTYPE`` and ``CATALOG_URIREF`` attributes.
-    ``fetch()`` and ``fetch_next()`` should populate the
-    ``records``, ``number_of_results`` and ``number_fetched``
-    attributes.
+    ``fetch_range()`` should populate the ``records``, ``number_of_results``,
+    ``number_fetched`` and ``range_fetched`` attributes.
     """
     number_of_results: Optional[int] = None
-    '''The total number of results for the query, including those
-    that have not been fetched yet.'''
-    number_fetched: int = 0
-    '''The number of results that has been fetched so far, or 0 if
-    no fetch has been performed yet.'''
-    records: List[Optional[Record]]
-    '''The records that have been fetched as instances of
-    (a subclass of) ``Record``.'''
+    """The total number of results for the query, or None if fetching
+    has not yet started and the number is not yet known."""
+    records: Dict[int, Record]
+    """The records that have been fetched as instances of
+    (a subclass of) ``Record``."""
     prepared_query: Optional[PreparedQueryType] = None
-    '''A transformed version of the query, available after
-    calling ``prepare_query()`` or ``set_query``.'''
+    """A transformed version of the query, available after
+    calling ``prepare_query()`` or ``set_query``."""
     READERTYPE: Optional[str] = None
-    '''The type of the reader, out of ``BIOGRAPHICAL`` and
-    ``BIBLIOGRAPHICAL`` (defined in the ``edpop_explorer`` package).'''
+    """The type of the reader, out of ``BIOGRAPHICAL`` and
+    ``BIBLIOGRAPHICAL`` (defined in the ``edpop_explorer`` package)."""
     CATALOG_URIREF: Optional[URIRef] = None
     IRI_PREFIX: Optional[str] = None
-    '''The prefix to use to create an IRI out of a record identifier.
+    """The prefix to use to create an IRI out of a record identifier.
     If an IRI cannot be created with a simple prefix, the 
     `identifier_to_iri` and `iri_to_identifier` methods have to be
-    overridden.'''
+    overridden."""
     FETCH_ALL_AT_ONCE = False
-    '''True if the reader is configured to fetch all records at once,
-    even if the user only needs a subset. If so, it may be economic to
-    save the state (by pickling) if the results are needed in a future 
-    session.'''
-    _graph: Optional[Graph] = None
+    """True if the reader is configured to fetch all records at once,
+    even if the user only needs a subset."""
+    DEFAULT_RECORDS_PER_PAGE: int = 10
+    """The number of records to fetch at a time using the ``fetch()``
+    method if not determined by user."""
+    _fetch_position: int = 0
+    """The index of the record that was fetched last. This is used by
+    the ``fetch()`` method to decide where to continue fetching."""
 
     def __init__(self):
-        self.records = []
+        self.records = {}
 
     @classmethod
     @abstractmethod
     def transform_query(cls, query: str) -> PreparedQueryType:
-        '''Return a version of the query that is prepared for use in the
+        """Return a version of the query that is prepared for use in the
         API.
 
         This method does not have to be called directly; instead
-        ``prepare_query()`` can be used.'''
+        ``prepare_query()`` can be used."""
         pass
 
     def prepare_query(self, query: str) -> None:
-        '''Prepare a query for use by the reader's API. Updates the
-        ``prepared_query`` attribute.'''
+        """Prepare a query for use by the reader's API. Updates the
+        ``prepared_query`` attribute."""
         self.prepared_query = self.transform_query(query)
 
     def set_query(self, query: PreparedQueryType) -> None:
-        '''Set an exact query. Updates the ``prepared_query``
-        attribute.'''
+        """Set an exact query. Updates the ``prepared_query``
+        attribute."""
         self.prepared_query = query
 
     def adjust_start_record(self, start_number: int) -> None:
         """Skip the given number of first records and start fetching
-        afterwards. Should be calling before the first time calling
-        ``fetch()``. The missing records in the ``records`` attribute
-        will be filled by ``None``s. The ``number_fetched`` attribute
-        will be adjusted as if the first records have been fetched.
-        This is mainly useful if the skipped records have already been
-        fetched but the original ``Reader`` object is not available anymore.
+        afterwards.
+
         This functionality may be ignored by readers that can only load
         all records at once; generally these are readers that return lazy
         records."""
-        if self.number_of_results is not None:
-            raise ReaderError(
-                "adjust_start_record should not be called after fetching."
-            )
-        self.number_fetched = start_number
-        self.records = [None for _ in range(start_number)]
+        self._fetch_position = start_number
 
-    @abstractmethod
     def fetch(
             self, number: Optional[int] = None
-    ):
-        '''Perform an initial or subsequent query. Most readers fetch
+    ) -> range:
+        """Perform an initial or subsequent query. Most readers fetch
         a limited number of records at once -- this number depends on
-        the reader but it may be adjusted using the ``number`` argument.
+        the reader but it may be adjusted using the ``number`` parameter.
         Other readers fetch all records at once and ignore the ``number``
-        argument. After fetching, the ``records`` and ``number_fetched``
-        attributes are adjusted and the ``number_of_results`` attribute
-        will be available.'''
+        parameter. After fetching, the records are available in the
+        ``records`` attribute and the ``number_of_results`` attribute
+        will be available. Returns the range of record indexes that has
+        been fetched."""
+        if self.fetching_exhausted:
+            return range(0)
+        if number is None:
+            number = self.DEFAULT_RECORDS_PER_PAGE
+        resulting_range = self.fetch_range(range(self._fetch_position,
+                                           self._fetch_position + number))
+        self._fetch_position = resulting_range.stop
+        return resulting_range
+
+    @abstractmethod
+    def fetch_range(self, range_to_fetch: range) -> range:
+        """Fetch a specific range of records. After fetching, the records
+        are available in the ``records`` attribute and the
+        ``number_of_results`` attribute will be available. If not all records
+        of the specified range exist, only the records that exist will be
+        fetched.
+
+        :param range_to_fetch: The range of records to fetch. ``step`` values
+            of ranges other than 1 are not supported and may be ignored.
+        :returns: The range of record indexes that has actually been fetched.
+        """
         pass
+
+    def get(self, index: int, allow_fetching: bool = True) -> Record:
+        """Get a record with a specific index. If the record is not yet
+        available, fetch additional records to make it available.
+
+        :param index: The number of the record to get.
+        :param allow_fetching: Allow fetching the record from an external
+            source if it was not yet fetched.
+        """
+        try:
+            return self.records[index]
+        except KeyError:
+            record = None
+            # Try to fetch, if it is allowed, and if there is a chance that
+            # it is successful (by verifying that index is not out of
+            # available range, if known)
+            if (allow_fetching and
+                    (self.number_of_results is None
+                     or self.number_of_results <= index)):
+                # Fetch and try again
+                self.fetch_range(range(index, index + 1))
+                record = self.records.get(index)
+            if record is not None:
+                return record
+            else:
+                raise NotFoundError(f"Item with index {index} is not available.")
 
     @classmethod
     @abstractmethod
@@ -180,16 +219,26 @@ class Reader(ABC):
 
         # Set namespace prefixes
         bind_common_namespaces(g)
-        
+
         return g
 
     @property
     def fetching_exhausted(self) -> bool:
-        """Return ``True`` if all results have been fetched. This is currently
-        implemented by simply checking if the ``number_of_results`` and
-        ``number_fetched`` attributes are equal."""
-        return self.number_fetched == self.number_of_results
-    
+        """Return ``True`` if all results have been fetched."""
+        return self.fetching_started and self.number_of_results == self.number_fetched
+
+    @property
+    def fetching_started(self) -> bool:
+        """``True`` if fetching has started, otherwise ``False``. As soon
+        as fetching has started, changing the query is not possible anymore."""
+        return self.number_of_results is not None
+
+    @property
+    def number_fetched(self) -> int:
+        """The number of results that has been fetched so far, or 0 if
+        no fetch has been performed yet."""
+        return len(self.records)
+
     def generate_identifier(self) -> str:
         """Generate an identifier for this reader that is unique for the
         combination of reader type and prepared query. This identifier can
@@ -207,7 +256,7 @@ class Reader(ABC):
         # which means that it has a __str__ method that gives a unique
         # string representation of its contents (at least as long as
         # it does not contain a very complex data structure, which should
-        # not be the case). For dataclasses, it is not guaranteed 
+        # not be the case). For dataclasses, it is not guaranteed
         prepared_query = str(self.prepared_query)
         return f"{readertype} | {prepared_query}"
 
@@ -227,14 +276,14 @@ class GetByIdBasedOnQueryMixin(ABC):
         reader.set_query(cls._prepare_get_by_id_query(identifier))
         reader.fetch()
         if reader.number_of_results == 0:
-            raise ReaderError("No results returned")
-        for record in reader.records:
+            raise NotFoundError("No results returned")
+        for record in reader.records.values():
             assert record is not None
             if record.identifier == identifier:
                 return record
         # Record with correct ID was not returned in first fetch -
         # give up.
-        raise ReaderError(
+        raise NotFoundError(
             f"Record with identifier {identifier} not present among "
             f"{reader.number_of_results} returned results."
         )

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -208,6 +208,12 @@ class Reader(ABC):
 
 
 class GetByIdBasedOnQueryMixin(ABC):
+    """Mixin for readers that are based on an API that has no special
+    way of retrieving single records -- instead, these readers fetch
+    single records using a list query. To use, make sure to override
+    the ``_prepare_get_by_id_query`` method, which defines the list
+    query that should be used."""
+
     @classmethod
     def get_by_id(cls, identifier: str) -> Record:
         reader = cls()

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -1,3 +1,5 @@
+"""Base reader class and strongly related functionality."""
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, List, Union
@@ -22,23 +24,23 @@ PreparedQueryType = Union[str, BasePreparedQuery]
 
 
 class Reader(ABC):
-    '''Base reader class (abstract).
+    """Base reader class (abstract).
 
     This abstract base class provides a common interface for all readers.
-    To use, instantiate a subclass, set a query using the 
+    To use, instantiate a subclass, set a query using the
     ``prepare_query()`` or ``set_query()`` method, call ``fetch()``
     and subsequently ``fetch_next()`` until you have the number
     of results that you want. The attributes ``number_of_results``,
-    ``number_fetched`` and ``records`` will be updated after 
+    ``number_fetched`` and ``records`` will be updated after
     fetching.
 
-    To create a concrete reader, make a subclass that implements the 
+    To create a concrete reader, make a subclass that implements the
     ``fetch()``, ``fetch_next()`` and ``transform_query()`` methods
     and set the ``READERTYPE`` and ``CATALOG_URIREF`` attributes.
-    ``fetch()`` and ``fetch_next()`` should populate the 
+    ``fetch()`` and ``fetch_next()`` should populate the
     ``records``, ``number_of_results`` and ``number_fetched``
     attributes.
-    '''
+    """
     number_of_results: Optional[int] = None
     '''The total number of results for the query, including those
     that have not been fetched yet.'''
@@ -76,12 +78,12 @@ class Reader(ABC):
         '''Return a version of the query that is prepared for use in the
         API.
 
-        This method does not have to be called directly; instead 
+        This method does not have to be called directly; instead
         ``prepare_query()`` can be used.'''
         pass
 
     def prepare_query(self, query: str) -> None:
-        '''Prepare a query for use by the reader's API. Updates the 
+        '''Prepare a query for use by the reader's API. Updates the
         ``prepared_query`` attribute.'''
         self.prepared_query = self.transform_query(query)
 
@@ -91,15 +93,15 @@ class Reader(ABC):
         self.prepared_query = query
 
     def adjust_start_record(self, start_number: int) -> None:
-        """Skip the given number of first records and start fetching 
+        """Skip the given number of first records and start fetching
         afterwards. Should be calling before the first time calling
         ``fetch()``. The missing records in the ``records`` attribute
         will be filled by ``None``s. The ``number_fetched`` attribute
         will be adjusted as if the first records have been fetched.
-        This is mainly useful if the skipped records have already been 
-        fetched but the original ``Reader`` object is not available anymore. 
-        This functionality may be ignored by readers that can only load 
-        all records at once; generally these are readers that return lazy 
+        This is mainly useful if the skipped records have already been
+        fetched but the original ``Reader`` object is not available anymore.
+        This functionality may be ignored by readers that can only load
+        all records at once; generally these are readers that return lazy
         records."""
         if self.number_of_results is not None:
             raise ReaderError(
@@ -124,12 +126,12 @@ class Reader(ABC):
     @classmethod
     @abstractmethod
     def get_by_id(cls, identifier: str) -> Record:
-        '''Get a single record by its identifier.'''
+        """Get a single record by its identifier."""
         pass
 
     @classmethod
     def get_by_iri(cls, iri: str) -> Record:
-        '''Get a single records by its IRI.'''
+        """Get a single records by its IRI."""
         identifier = cls.iri_to_identifier(iri)
         return cls.get_by_id(identifier)
 
@@ -193,7 +195,7 @@ class Reader(ABC):
         combination of reader type and prepared query. This identifier can
         be used when the reader has to be reused across sessions by
         pickling and unpickling.
-        
+
         Note: while the identifier is guaranteed to be unique, there
         is no guarantee that the generated identifier is the same for
         every combination of reader type and prepared query."""
@@ -244,6 +246,8 @@ class GetByIdBasedOnQueryMixin(ABC):
 
 
 class ReaderError(Exception):
+    """Generic exception for failures in ``Reader`` class. More specific errors
+    derive from this class."""
     pass
 
 

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -3,7 +3,7 @@ import sqlite3
 from rdflib import URIRef
 import requests
 from appdirs import AppDirs
-from typing import List, Optional
+from typing import Optional
 
 from edpop_explorer import (
     Reader, BibliographicalRecord, ReaderError, Field, BIBLIOGRAPHICAL

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -24,6 +24,7 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/fbtee/"
     prepared_query: Optional[SQLPreparedQuery] = None
+    FETCH_ALL_AT_ONCE = True
 
     def __init__(self):
         self.database_file = Path(
@@ -93,6 +94,9 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             record.contributors.append(Field(author[1]))
 
     def fetch(self, number: Optional[int] = None) -> None:
+        # This method always fetches all data at once. This could be avoided,
+        # but it is inexpensive because the data is locally available and
+        # the dataset is small.
         self.prepare_data()
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')

--- a/edpop_explorer/readers/sbtireader.py
+++ b/edpop_explorer/readers/sbtireader.py
@@ -127,13 +127,15 @@ class SBTIReader(Reader):
         # No transformation needed
         return query
 
-    def fetch(self, number: Optional[int] = None) -> None:
+    def fetch_range(self, range_to_fetch: range) -> range:
         if self.prepared_query is None:
             raise ReaderError('First call prepare_query')
         if self.fetching_exhausted:
-            return
-        start_record = len(self.records)
-        results = self._perform_query(start_record, number)
-        self.records.extend(results)
-        self.number_fetched = len(self.records)
+            return range(0)
+        start_record = range_to_fetch.start
+        number_to_fetch = range_to_fetch.stop - start_record
+        results = self._perform_query(start_record, number_to_fetch)
+        for i, result in enumerate(results):
+            self.records[i] = result
+        return range(start_record, start_record + len(results))
 

--- a/edpop_explorer/readers/stcn.py
+++ b/edpop_explorer/readers/stcn.py
@@ -35,7 +35,7 @@ class STCNReader(SparqlReader):
         super().__init__()
 
     @classmethod
-    def _convert_record(
+    def convert_record(
         cls, graph: Graph, record: BibliographicalRDFRecord
     ) -> None:
         SCHEMA = Namespace('http://schema.org/')

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -23,6 +23,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
     FETCH_ALL_AT_ONCE = True
 
     def __init__(self):
+        super().__init__()
         self.database_file = Path(
             AppDirs('edpop-explorer', 'cdh').user_data_dir
         ) / self.DATABASE_FILENAME
@@ -67,7 +68,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
             arguments=[identifier_int]
         )
 
-    def fetch(self, number: Optional[int] = None) -> None:
+    def fetch_range(self, range_to_fetch: range) -> range:
         self.prepare_data()
 
         # This method fetches all records immediately, because the data is
@@ -76,7 +77,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
         if not self.prepared_query:
             raise ReaderError('No query has been set')
         if self.fetching_exhausted:
-            return
+            return range(0)
 
         cur = self.con.cursor()
         columns = [x[1] for x in cur.execute('PRAGMA table_info(editions)')]
@@ -89,15 +90,14 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
             + ' ORDER BY E.id',
             self.prepared_query.arguments,
         )
-        self.records = []
-        for row in res:
+        for i, row in enumerate(res):
             data = {}
-            for i in range(len(columns)):
-                data[columns[i]] = row[i]
+            for j in range(len(columns)):
+                data[columns[j]] = row[j]
             record = self._convert_record(data)
-            self.records.append(record)
+            self.records[i] = record
         self.number_of_results = len(self.records)
-        self.number_fetched = self.number_of_results
+        return range(0, len(self.records))
 
     def _convert_record(self, data: dict) -> BibliographicalRecord:
         record = BibliographicalRecord(from_reader=self.__class__)

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -20,6 +20,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/ustc/"
     prepared_query: Optional[SQLPreparedQuery] = None
+    FETCH_ALL_AT_ONCE = True
 
     def __init__(self):
         self.database_file = Path(

--- a/edpop_explorer/record.py
+++ b/edpop_explorer/record.py
@@ -34,7 +34,7 @@ class Record:
     While this is a non-abstract base class, no fields are
     defined here -- these should be added in subclasses. ``Record``
     and its subclasses should be created by calling the constructor
-    with the ``Reader`` class as the ``from_reader`` argument
+    with the ``Reader`` class as the ``from_reader`` parameter
     and by setting the ``data``, ``link``, ``identifier`` and
     ``subject_node`` attributes (all are optional but recommended),
     as well as the fields that are defined by the subclass.

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -4,6 +4,8 @@ import json
 from SPARQLWrapper import SPARQLWrapper, SPARQLExceptions, JSON as JSONFormat
 from abc import abstractmethod
 
+from typing_extensions import override
+
 from edpop_explorer import (
     Reader, Record, BibliographicalRecord, ReaderError, RecordError,
     LazyRecordMixin
@@ -106,6 +108,7 @@ class SparqlReader(Reader):
     FETCH_ALL_AT_ONCE = True
 
     @classmethod
+    @override
     def transform_query(cls, query: str):
         return prepare_listing_query(
             name_predicate=cls.name_predicate,
@@ -114,14 +117,17 @@ class SparqlReader(Reader):
         )
 
     @classmethod
+    @override
     def get_by_id(cls, identifier: str) -> Record:
         return cls._create_lazy_record(identifier)
 
-    def fetch(self, number: Optional[int] = None):
+    @override
+    def fetch_range(self, range_to_fetch: range) -> range:
+        # Fetch all records at one, because this is an expensive operation.
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
         if self.fetching_exhausted:
-            return
+            return range(0, 0)
         wrapper = SPARQLWrapper(self.endpoint)
         wrapper.setReturnFormat(JSONFormat)
         wrapper.setQuery(self.prepared_query)
@@ -133,17 +139,17 @@ class SparqlReader(Reader):
             )
         assert isinstance(response, dict)
         results = response['results']['bindings']
-        self.records = []
+        self.records = {}
         self.number_of_results = len(results)
-        for result in results:
+        for i, result in enumerate(results):
             iri = result['s']['value']
             name = result['name']['value']
-            self.records.append(self._create_lazy_record(iri, name))
-        self.number_fetched = self.number_of_results
+            self.records[i] = self._create_lazy_record(iri, name)
+        return range(0, self.number_of_results)
 
     @classmethod
     @abstractmethod
-    def _convert_record(cls, graph: Graph, record: Record) -> None:
+    def convert_record(cls, graph: Graph, record: Record) -> None:
         '''Convert data from an RDF graph to Fields in a Record. The 
         Record is changed in-place.'''
         pass

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -103,6 +103,7 @@ class SparqlReader(Reader):
     name_predicate: str
     filter: Optional[str] = None
     prepared_query: Optional[str]
+    FETCH_ALL_AT_ONCE = True
 
     @classmethod
     def transform_query(cls, query: str):

--- a/edpop_explorer/sql.py
+++ b/edpop_explorer/sql.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from typing import List, Union
 
-from edpop_explorer import PreparedQuery
+from edpop_explorer import BasePreparedQuery
 
 
 @dataclass
-class SQLPreparedQuery(PreparedQuery):
+class SQLPreparedQuery(BasePreparedQuery):
     where_statement: str
     arguments: List[Union[str, int]]

--- a/edpop_explorer/srureader.py
+++ b/edpop_explorer/srureader.py
@@ -27,8 +27,6 @@ class SRUReader(GetByIdBasedOnQueryMixin, Reader):
     query: Optional[str] = None
     session: requests.Session
     '''The ``Session`` object of the ``requests`` library.'''
-    DEFAULT_RECORDS_PER_PAGE: int = 10
-    '''The number of records to fetch at a time if not determined by user.'''
 
     def __init__(self):
         # Set a session to allow reuse of HTTP sessions and to set additional

--- a/edpop_explorer/srureader.py
+++ b/edpop_explorer/srureader.py
@@ -79,15 +79,17 @@ class SRUReader(GetByIdBasedOnQueryMixin, Reader):
     def prepare_query(self, query) -> None:
         self.prepared_query = self.transform_query(query)
 
-    def fetch(self, number: Optional[int] = None) -> None:
-        if self.records is None or self.number_fetched is None:
-            self.records = []
-            self.number_fetched = 0
+    def fetch_range(self, range_to_fetch: range) -> range:
+        # SRU provides paged retrieve using a start record (that starts at
+        # 1, while we start at 0) and a maximum number of results.
         if self.fetching_exhausted:
-            return
+            return range(0, 0)
         if self.prepared_query is None:
             raise ReaderError('First call prepare_query')
-        start_number = self.number_fetched + 1  # SRU starts at 1
-        results = self._perform_query(start_number, number)
-        self.records.extend(results)
-        self.number_fetched = len(self.records)
+        start_number = range_to_fetch.start
+        start_number_sru = start_number + 1  # SRU starts at 1
+        records_to_fetch = range_to_fetch.stop - range_to_fetch.start
+        results = self._perform_query(start_number_sru, records_to_fetch)
+        for i, result in enumerate(results):
+            self.records[i + start_number] = result
+        return range(start_number, start_number + len(results))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   'rdflib>=7.0.0,<8',
   'Pygments',
   'xmltodict>=0.13.0',
+  'typing_extensions',
 ]
 
 description = "Common interface to multiple library catalogues and bibliographical databases"

--- a/tests/test_allreaders.py
+++ b/tests/test_allreaders.py
@@ -1,5 +1,5 @@
-'''Test all readers for basic sanity, without invoking methods that could
-access the internet or manipulate files.'''
+"""Test all readers for basic sanity, without invoking methods that could
+access the internet or manipulate files."""
 
 import pytest
 import warnings
@@ -50,9 +50,10 @@ def test_catalog_to_graph(readercls: Type[Reader]):
 def test_realrequest(readercls: Type[Reader]):
     reader = readercls()
     reader.prepare_query("gruninger")
-    reader.fetch(5)
+    rng = reader.fetch(5)
     assert reader.number_of_results is not None
     assert reader.number_fetched == len(reader.records)
+    assert rng == range(0, reader.number_fetched)
     if not reader.fetching_exhausted:
         # Assert that maximum number of results is respected if reader does
         # not fetch all results at once
@@ -70,23 +71,28 @@ def test_realrequest(readercls: Type[Reader]):
             samerecord = reader.get_by_iri(iri)
             assert samerecord.iri == iri
         else:
-            warnings.warn(
-                UserWarning(f"Record {record} has empty IRI")
-            )
+            warnings.warn(UserWarning(f"Record {record} has empty IRI"))
     # Perform a second fetch
     fetched_before = reader.number_fetched
-    reader.fetch()  # Do not pass number of results to test that as well
+    rng2 = reader.fetch()  # Do not pass number of results to test that as well
     # If not all records had been fetched already, more records
     # should be available now. Otherwise, nothing should have
     # changed.
     if fetched_before < reader.number_of_results:
         assert reader.number_fetched > fetched_before
+        assert rng2.start == fetched_before
+        assert rng2.stop == reader.number_fetched
         # Assert that the last record of the previous fetch is not the same as
         # the first record of the current fetch
         record1 = reader.records[fetched_before - 1]
         record2 = reader.records[fetched_before]
         assert record1 is not None and record2 is not None
-        if record1.identifier is not None:
-            assert record1.identifier != record2.identifier
+        if record1.identifier is not None and record1.identifier == record2.identifier:
+            # Both records have the same identifier, which could mean that
+            # there was a mistake with the offsets. But just give a warning,
+            # because there are APIs that (by mistake?) return duplicated
+            # records.
+            warnings.warn(UserWarning("Last record from first fetch is same as first record from second fetch"))
     else:
         assert reader.number_fetched == fetched_before
+        assert rng2 == range(0)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -96,3 +96,16 @@ def test_getbyidbasedonquerymixin_multiplereturned():
 def test_getbyidbasedonquerymixin_nonereturned():
     with pytest.raises(ReaderError):
        SimpleReaderGetByIdBasedOnQuery.get_by_id("nonematching")
+
+
+def test_generate_identifier():
+    reader = SimpleReader()
+    reader.prepare_query("Hoi")
+    identifier = reader.generate_identifier()
+    # A new reader with the same query should have the same identifier. Now,
+    # also perform a fetch.
+    reader2 = SimpleReader()
+    reader2.prepare_query("Hoi")
+    reader2.fetch()
+    identifier2 = reader2.generate_identifier()
+    assert identifier == identifier2

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from typing_extensions import override
 
@@ -41,7 +40,7 @@ class SimpleReader(Reader):
     @classmethod
     @override
     def get_by_id(cls, identifier: str) -> Record:
-        if not int(identifier) in range(cls.NUMBER_OF_ITEMS):
+        if int(identifier) not in range(cls.NUMBER_OF_ITEMS):
             raise NotFoundError
         record = Record(cls)
         record.identifier = identifier
@@ -115,7 +114,7 @@ def test_get_no_fetching():
     reader = SimpleReader()
     reader.set_query("test")
     with pytest.raises(NotFoundError):
-        record = reader.get(5, False)
+        reader.get(5, False)
 
 
 class SimpleReaderGetByIdBasedOnQuery(GetByIdBasedOnQueryMixin, SimpleReader):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,32 +1,52 @@
+from typing import Optional
+
+from typing_extensions import override
+
 import pytest
 
 from rdflib import URIRef, RDF
 
 from edpop_explorer import (
-    Record, Reader, ReaderError, EDPOPREC, GetByIdBasedOnQueryMixin
+    Record,
+    Reader,
+    ReaderError,
+    EDPOPREC,
+    GetByIdBasedOnQueryMixin,
+    NotFoundError,
 )
 
 
 class SimpleReader(Reader):
-    CATALOG_URIREF = URIRef('http://example.com/reader')
+    """A simple reader which always yields 20 items which have as their
+    ID the index number."""
+
+    CATALOG_URIREF = URIRef("http://example.com/reader")
     IRI_PREFIX = "http://example.com/records/reader/"
+    NUMBER_OF_ITEMS = 20
 
-    def fetch(self):
-        self.records = [Record(self.__class__)]
-        self.number_of_results = 1
-        self.number_fetched = 1
-
-    def fetch_next(self):
-        pass
+    @override
+    def fetch_range(self, range_to_fetch: range) -> range:
+        if range_to_fetch.stop > self.NUMBER_OF_ITEMS:
+            range_to_fetch = range(range_to_fetch.start, self.NUMBER_OF_ITEMS)
+        for i in range_to_fetch:
+            self.records[i] = self.get_by_id(str(i))
+        self.number_of_results = self.NUMBER_OF_ITEMS
+        return range_to_fetch
 
     @classmethod
+    @override
     def transform_query(cls, query):
         return query.capitalize()
 
-    def get_by_id(self, identifier: str) -> Record:
-        record = Record(self.__class__)
+    @classmethod
+    @override
+    def get_by_id(cls, identifier: str) -> Record:
+        if not int(identifier) in range(cls.NUMBER_OF_ITEMS):
+            raise NotFoundError
+        record = Record(cls)
         record.identifier = identifier
         return record
+
 
 class SimpleReaderNoIRIPrefix(SimpleReader):
     IRI_PREFIX = None
@@ -62,25 +82,71 @@ def test_identifier_to_iri():
     assert SimpleReader.identifier_to_iri("1") == expected_iri
 
 
+def test_fetch():
+    reader = SimpleReader()
+    reader.set_query("test")  # Ignored by SimpleReader
+    to_fetch = 8
+    reader.fetch(to_fetch)
+    assert reader.number_of_results == 20
+    assert reader.number_fetched == to_fetch
+    record = reader.get(5, False)
+    assert isinstance(record, Record)
+    # Fetch the next 8
+    reader.fetch(to_fetch)
+    record = reader.get(12, False)
+    assert isinstance(record, Record)
+    # Fetch the rest
+    reader.fetch(to_fetch)
+    assert reader.fetching_exhausted
+    assert reader.number_fetched == reader.number_of_results
+    with pytest.raises(NotFoundError):
+        # Number 20 should not exist
+        record = reader.get(20, False)
+
+
+def test_get_allow_fetching():
+    reader = SimpleReader()
+    reader.set_query("test")
+    record = reader.get(5, True)
+    assert isinstance(record, Record)
+
+
+def test_get_no_fetching():
+    reader = SimpleReader()
+    reader.set_query("test")
+    with pytest.raises(NotFoundError):
+        record = reader.get(5, False)
+
+
 class SimpleReaderGetByIdBasedOnQuery(GetByIdBasedOnQueryMixin, SimpleReader):
+    FETCH_ALL_AT_ONCE = True
+
     @classmethod
     def _prepare_get_by_id_query(cls, identifier: str) -> str:
         return f"get {identifier}"
 
-    def fetch(self):
-        if not self.prepared_query:
-            return
+    @override
+    def fetch_range(self, range_to_fetch: range) -> range:
+        # To simplify, fetch all records at once
         if self.prepared_query == "get manymatching":
-            self.records = [Record(self.__class__), Record(self.__class__)]
-            self.number_fetched = self.number_of_results = 2
+            self.records = {
+                0: Record(self.__class__),
+                1: Record(self.__class__),
+            }
+            self.number_of_results = 2
+            return range(0, 2)
         elif self.prepared_query == "get nonematching":
-            self.records = []
-            self.number_fetched = self.number_of_results = 0
+            self.records = {}
+            self.number_of_results = 0
+            return range(0, 0)
         elif self.prepared_query.startswith("get "):
             record = Record(self.__class__)
             record.identifier = self.prepared_query[4:]
-            self.records = [record]
-            self.number_fetched = self.number_of_results = 1
+            self.records = {
+                0: record,
+            }
+            self.number_of_results = 1
+            return range(0, 1)
 
 
 def test_getbyidbasedonquerymixin():
@@ -90,12 +156,12 @@ def test_getbyidbasedonquerymixin():
 
 def test_getbyidbasedonquerymixin_multiplereturned():
     with pytest.raises(ReaderError):
-       SimpleReaderGetByIdBasedOnQuery.get_by_id("manymatching")
+        SimpleReaderGetByIdBasedOnQuery.get_by_id("manymatching")
 
 
 def test_getbyidbasedonquerymixin_nonereturned():
     with pytest.raises(ReaderError):
-       SimpleReaderGetByIdBasedOnQuery.get_by_id("nonematching")
+        SimpleReaderGetByIdBasedOnQuery.get_by_id("nonematching")
 
 
 def test_generate_identifier():


### PR DESCRIPTION
So far, `edpop-explorer` only allowed fetching by batch, starting with the first record. However, to use in combination with the VRE backend it should be possible to fetch a specific range, even if records with a lower index have not yet been retrieved.

This PR also adds a method `generate_identifier` to readers which create a string that is unique for each combination of reader type and query. This can be used to cache a `Record` object (using pickle) for reuse at a later time.