### PR TITLE
Add short name and descriptions of all readers to RDF representation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint with ruff
         run: |
           pip install ruff
-          ruff --output-format=github --target-version=py38 .
+          ruff check --output-format=github --target-version=py38 .
       - name: Test with pytest
         run: |
           pytest

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, Union, Dict
-from rdflib import Graph, RDF, URIRef
+from rdflib import Graph, RDF, URIRef, SDO, Literal
 from urllib.parse import quote, unquote
 
 
@@ -59,6 +59,12 @@ class Reader(ABC):
     If an IRI cannot be created with a simple prefix, the 
     `identifier_to_iri` and `iri_to_identifier` methods have to be
     overridden."""
+    SHORT_NAME: Optional[str] = None
+    """Short name of the corresponding catalogue, to be used in
+    user interfaces."""
+    DESCRIPTION: Optional[str] = None
+    """Information about the contents of the corresponding catalogue, 
+    to be used in user interfaces."""
     FETCH_ALL_AT_ONCE = False
     """True if the reader is configured to fetch all records at once,
     even if the user only needs a subset."""
@@ -215,6 +221,12 @@ class Reader(ABC):
         elif cls.READERTYPE == BIBLIOGRAPHICAL:
             rdfclass = EDPOPREC.BibliographicalCatalog
         g.add((cls.CATALOG_URIREF, RDF.type, rdfclass))
+
+        # Add name and description
+        if cls.SHORT_NAME:
+            g.add((cls.CATALOG_URIREF, SDO.name, Literal(cls.SHORT_NAME)))
+        if cls.DESCRIPTION:
+            g.add((cls.CATALOG_URIREF, SDO.description, Literal(cls.DESCRIPTION)))
 
         # Set namespace prefixes
         bind_common_namespaces(g)

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -227,6 +227,8 @@ class Reader(ABC):
             g.add((cls.CATALOG_URIREF, SDO.name, Literal(cls.SHORT_NAME)))
         if cls.DESCRIPTION:
             g.add((cls.CATALOG_URIREF, SDO.description, Literal(cls.DESCRIPTION)))
+        if (slug := cls.catalog_slug) is not None:
+            g.add((cls.CATALOG_URIREF, ))
 
         # Set namespace prefixes
         bind_common_namespaces(g)
@@ -270,6 +272,11 @@ class Reader(ABC):
         # not be the case). For dataclasses, it is not guaranteed
         prepared_query = str(self.prepared_query)
         return f"{readertype} | {prepared_query}"
+
+    @property
+    def catalog_slug(self) -> Optional[str]:
+        if self.CATALOG_URIREF:
+            return self.CATALOG_URIREF.split("/")[-1]
 
 
 class GetByIdBasedOnQueryMixin(ABC):

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -228,7 +228,7 @@ class Reader(ABC):
         if cls.DESCRIPTION:
             g.add((cls.CATALOG_URIREF, SDO.description, Literal(cls.DESCRIPTION)))
         if (slug := cls.catalog_slug) is not None:
-            g.add((cls.CATALOG_URIREF, ))
+            g.add((cls.CATALOG_URIREF, SDO.identifier, Literal(slug)))
 
         # Set namespace prefixes
         bind_common_namespaces(g)

--- a/edpop_explorer/readers/bibliopolis.py
+++ b/edpop_explorer/readers/bibliopolis.py
@@ -3,6 +3,9 @@ from edpop_explorer import Record, SRUReader
 
 
 class BibliopolisReader(SRUReader):
+    # Note that this reader is currently deactivated by default because
+    # the API is not working. It is not possible for the moment to
+    # test this reader.
     sru_url = 'http://jsru.kb.nl/sru/sru'
     sru_version = '1.2'
     HPB_LINK = 'http://hpb.cerl.org/record/{}'

--- a/edpop_explorer/readers/bibliopolis.py
+++ b/edpop_explorer/readers/bibliopolis.py
@@ -10,6 +10,7 @@ class BibliopolisReader(SRUReader):
         'https://edpop.hum.uu.nl/readers/bibliopolis'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/bibliopolis/"
+    SHORT_NAME = "Bibliopolis"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/bnf.py
+++ b/edpop_explorer/readers/bnf.py
@@ -15,6 +15,7 @@ class BnFReader(SRUMarc21BibliographicalReader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/bnf/"
     SHORT_NAME = "Bibliothèque nationale de France (BnF)"
+    DESCRIPTION = "General catalogue of the French National Library"
     _title_field_subfield = ('200', 'a')
     _alternative_title_field_subfield = ('500', 'a')
     _publisher_field_subfield = ('201', 'c')

--- a/edpop_explorer/readers/bnf.py
+++ b/edpop_explorer/readers/bnf.py
@@ -14,6 +14,7 @@ class BnFReader(SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/bnf'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/bnf/"
+    SHORT_NAME = "Bibliothèque nationale de France (BnF)"
     _title_field_subfield = ('200', 'a')
     _alternative_title_field_subfield = ('500', 'a')
     _publisher_field_subfield = ('201', 'c')

--- a/edpop_explorer/readers/cerl_thesaurus.py
+++ b/edpop_explorer/readers/cerl_thesaurus.py
@@ -15,6 +15,11 @@ class CERLThesaurusReader(SRUReader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/cerlthesaurus/"
     SHORT_NAME = "CERL Thesaurus"
+    DESCRIPTION = "The CERL Thesaurus file contains forms of imprint " \
+        "places, imprint names, personal names and corporate names as "\
+        "found in material printed before the middle of the nineteenth "\
+        "century - including variant spellings, forms in Latin and "\
+        "other languages, and fictitious names."
 
     @classmethod
     def _get_acceptable_names(

--- a/edpop_explorer/readers/cerl_thesaurus.py
+++ b/edpop_explorer/readers/cerl_thesaurus.py
@@ -14,6 +14,7 @@ class CERLThesaurusReader(SRUReader):
         'https://edpop.hum.uu.nl/readers/cerlthesaurus'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/cerlthesaurus/"
+    SHORT_NAME = "CERL Thesaurus"
 
     @classmethod
     def _get_acceptable_names(

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -24,6 +24,7 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/fbtee/"
     prepared_query: Optional[SQLPreparedQuery] = None
     FETCH_ALL_AT_ONCE = True
+    SHORT_NAME = "French Book Trade in Enlightenment Europe (FBTEE)"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -25,6 +25,8 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     prepared_query: Optional[SQLPreparedQuery] = None
     FETCH_ALL_AT_ONCE = True
     SHORT_NAME = "French Book Trade in Enlightenment Europe (FBTEE)"
+    DESCRIPTION = "Mapping the Trade of the Société Typographique de " \
+        "Neuchâtel, 1769-1794"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/gallica.py
+++ b/edpop_explorer/readers/gallica.py
@@ -14,6 +14,7 @@ def _force_list(data) -> list:
     else:
         return [data]
 
+
 def _force_string(data) -> Optional[str]:
     '''Transform data into one string or None. Can be used if a single 
     string is expected, but if there is a possibility that it is a
@@ -38,6 +39,8 @@ class GallicaReader(SRUReader):
     DOCUMENT_API_URL = "https://gallica.bnf.fr/services/OAIRecord?ark={}"
     IDENTIFIER_PREFIX = "https://gallica.bnf.fr/"
     SHORT_NAME = "Gallica"
+    DESCRIPTION = "Digital library of the Bibliothèque nationale de France " \
+        "and its partners"
 
     @classmethod
     def _convert_record(cls, sruthirecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/gallica.py
+++ b/edpop_explorer/readers/gallica.py
@@ -37,6 +37,7 @@ class GallicaReader(SRUReader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/gallica/"
     DOCUMENT_API_URL = "https://gallica.bnf.fr/services/OAIRecord?ark={}"
     IDENTIFIER_PREFIX = "https://gallica.bnf.fr/"
+    SHORT_NAME = "Gallica"
 
     @classmethod
     def _convert_record(cls, sruthirecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/hpb.py
+++ b/edpop_explorer/readers/hpb.py
@@ -15,6 +15,14 @@ class HPBReader(SRUMarc21BibliographicalReader):
     )
     READERTYPE = BIBLIOGRAPHICAL
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/hpb/"
+    SHORT_NAME = "Heritage of the Printed Book (HPB)"
+    DESCRIPTION = (
+        "The HPB Database (previously called the Hand Press Book Database) "
+        "is a steadily growing collection of files of catalogue records from "
+        "major European and North American research libraries covering items "
+        "of European printing of the hand-press period (c.1455-c.1830) "
+        "integrated into one file."
+    )
 
     @classmethod
     def transform_query(cls, query: str) -> str:

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -13,6 +13,8 @@ class KBReader(SRUReader):
     )
     READERTYPE = BIBLIOGRAPHICAL
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/kb/"
+    SHORT_NAME = "Koninklijke Bibliotheek (KB)"
+    DESCRIPTION = "General catalogue of KB, national library of The Netherlands."
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/pierre_belle.py
+++ b/edpop_explorer/readers/pierre_belle.py
@@ -14,6 +14,8 @@ class PierreBelleReader(Reader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/pierre_belle/"
     FETCH_ALL_AT_ONCE = True
     SHORT_NAME = "Pierre and Belle"
+    DESCRIPTION = "Bibliography of early modern editions of Pierre de " \
+        "Provence et la Belle Maguelonne (ca. 1470-ca. 1800)"
 
     @classmethod
     def _convert_record(cls, rawrecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/pierre_belle.py
+++ b/edpop_explorer/readers/pierre_belle.py
@@ -13,6 +13,7 @@ class PierreBelleReader(Reader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/pierre_belle/"
     FETCH_ALL_AT_ONCE = True
+    SHORT_NAME = "Pierre and Belle"
 
     @classmethod
     def _convert_record(cls, rawrecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/sbtireader.py
+++ b/edpop_explorer/readers/sbtireader.py
@@ -19,6 +19,8 @@ class SBTIReader(Reader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/sbti/"
     DEFAULT_RECORDS_PER_PAGE = 10
     SHORT_NAME = "Scottish Book Trade Index (SBTI)"
+    DESCRIPTION = "An index of the names, trades and addresses of people "\
+        "involved in printing in Scotland up to 1850"
 
     @classmethod
     def _get_name_field(cls, data: dict) -> Optional[Field]:

--- a/edpop_explorer/readers/sbtireader.py
+++ b/edpop_explorer/readers/sbtireader.py
@@ -18,6 +18,7 @@ class SBTIReader(Reader):
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/sbti/"
     DEFAULT_RECORDS_PER_PAGE = 10
+    SHORT_NAME = "Scottish Book Trade Index (SBTI)"
 
     @classmethod
     def _get_name_field(cls, data: dict) -> Optional[Field]:

--- a/edpop_explorer/readers/stcn.py
+++ b/edpop_explorer/readers/stcn.py
@@ -30,7 +30,8 @@ class STCNReader(SparqlReader):
         'https://edpop.hum.uu.nl/readers/stcn'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/stcn/"
-    SHORT_NAME = "Short Title Catalogue Netherlands (STCN)"
+    SHORT_NAME = "Short-Title Catalogue Netherlands (STCN)"
+    DESCRIPTION = "National biography of The Netherlands until 1801"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/stcn.py
+++ b/edpop_explorer/readers/stcn.py
@@ -30,6 +30,7 @@ class STCNReader(SparqlReader):
         'https://edpop.hum.uu.nl/readers/stcn'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/stcn/"
+    SHORT_NAME = "Short Title Catalogue Netherlands (STCN)"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -22,6 +22,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
     prepared_query: Optional[SQLPreparedQuery] = None
     FETCH_ALL_AT_ONCE = True
     SHORT_NAME = "Universal Short Title Catalogue (USTC)"
+    DESCRIPTION = "An open access bibliography of early modern print culture"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -21,6 +21,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/ustc/"
     prepared_query: Optional[SQLPreparedQuery] = None
     FETCH_ALL_AT_ONCE = True
+    SHORT_TITLE = "Universal Short Title Catalogue (USTC)"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -21,7 +21,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/ustc/"
     prepared_query: Optional[SQLPreparedQuery] = None
     FETCH_ALL_AT_ONCE = True
-    SHORT_TITLE = "Universal Short Title Catalogue (USTC)"
+    SHORT_NAME = "Universal Short Title Catalogue (USTC)"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -31,6 +31,8 @@ class VD16Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vd16'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd16/"
+    SHORT_NAME = "VD16"
+    DESCRIPTION = "Verzeichnis der im deutschen Sprachbereich erschienenen Drucke des 16. Jahrhunderts"
 
     @classmethod
     def transform_query(cls, query: str) -> str:
@@ -48,6 +50,8 @@ class VD17Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vd17'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd17/"
+    SHORT_NAME = "VD16"
+    DESCRIPTION = "Verzeichnis der im deutschen Sprachbereich erschienenen Drucke des 17. Jahrhunderts"
 
     @classmethod
     def transform_query(cls, query: str) -> str:
@@ -64,6 +68,8 @@ class VD18Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vd18'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd18/"
+    SHORT_NAME = "VD16"
+    DESCRIPTION = "Verzeichnis der im deutschen Sprachbereich erschienenen Drucke des 18. Jahrhunderts"
 
     @classmethod
     def transform_query(cls, query: str) -> str:

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -50,7 +50,7 @@ class VD17Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vd17'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd17/"
-    SHORT_NAME = "VD16"
+    SHORT_NAME = "VD17"
     DESCRIPTION = "Verzeichnis der im deutschen Sprachbereich erschienenen Drucke des 17. Jahrhunderts"
 
     @classmethod
@@ -68,7 +68,7 @@ class VD18Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vd18'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd18/"
-    SHORT_NAME = "VD16"
+    SHORT_NAME = "VD18"
     DESCRIPTION = "Verzeichnis der im deutschen Sprachbereich erschienenen Drucke des 18. Jahrhunderts"
 
     @classmethod

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -96,6 +96,8 @@ class VDLiedReader(VDCommonMixin, SRUMarc21BibliographicalReader):
         'https://edpop.hum.uu.nl/readers/vdlied'
     )
     IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vdlied/"
+    SHORT_NAME = "VDLied"
+    DESCRIPTION = "Das Verzeichnis der deutschsprachigen Liedflugschriften"
 
     @classmethod
     def transform_query(cls, query: str) -> str:


### PR DESCRIPTION
This is necessary to show the names and descriptions of the catalogues in the EDPOP user interface. This PR is quite trivial, but I have added some properties to the Catalog type. I will add these to the ontology at a later point, when I expect no more changes.