### PR TITLE
Automatically download databases of new readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ print culture. The VRE will rely on `edpop-explorer`.
 ## Install
 
 **Please note that `edpop-explorer` is still under active development
-and that while it might be useful, some important features are still
-missing and the public API is not yet stable.**
+and that while it might be useful, the public API is not yet stable.**
 
 `edpop-explorer` can easily be installed from PyPI:
 
@@ -40,6 +39,20 @@ package. The commandline tool can be run using the `edpopx` command.
 (On Windows it may be that the `edpopx` command does not become available 
 on the path. In that case you can also run it using the command `python 
 -m edpop_explorer`.)
+
+EDPOP Explorer comes with a number of pre-installed readers. Most of these
+readers connect to external APIs. Please take into account that there is 
+always a chance that some readers are (temporarily) not available or that
+the public interfaces have changed. In the latter case, you are welcome
+to file an issue or create a fix.
+
+A limited number of pre-installed readers do not work with external APIs
+but with pre-downloaded databases. Where possible,
+these databases are automatically downloaded the first time. In case of the
+USTC reader, an automatic download is not provided but the database file
+may be obtained from the project team. If this database is not available,
+an exception will be given with an indication as to where to put the
+database file.
 
 ## Basic usage
 
@@ -84,8 +97,11 @@ the query you want to perform, such as:
 
     # hpb gruninger
 
-This will give you the number of results and a summary of the first ten
-results. To load more results, use the `next` command:
+Before executing the query, EDPOP Explorer will show the way the query is
+transformed before calling the external API. In many cases, including
+HPB, the transformed query is exactly the same as the user-inputted query.
+After performing the query, you will see the number of results and a 
+summary of the first ten results. To load more results, use the `next` command:
 
     # next
 

--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -2,7 +2,8 @@ __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
     'Field', 'FieldError', 'LocationField',
     'Reader', 'ReaderError', 'NotFoundError',
-    'GetByIdBasedOnQueryMixin', 'BasePreparedQuery', 'PreparedQueryType',
+    'GetByIdBasedOnQueryMixin', 'DatabaseFileMixin',
+    'BasePreparedQuery', 'PreparedQueryType',
     'Record', 'RawData', 'RecordError', 'BibliographicalRecord',
     'BiographicalRecord', 'LazyRecordMixin',
     'SRUReader',
@@ -20,7 +21,7 @@ from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
 from .fields import Field, FieldError, LocationField
 from .reader import (
     Reader, ReaderError, GetByIdBasedOnQueryMixin, BasePreparedQuery,
-    PreparedQueryType, NotFoundError
+    PreparedQueryType, NotFoundError, DatabaseFileMixin
 )
 from .record import (
     Record, RawData, RecordError, BibliographicalRecord, BiographicalRecord,

--- a/edpop_explorer/rdf.py
+++ b/edpop_explorer/rdf.py
@@ -3,7 +3,7 @@
 from rdflib.namespace import Namespace
 from rdflib import Graph, RDF, RDFS
 
-EDPOPREC = Namespace('https://dhstatic.hum.uu.nl/edpop-records/latest/')
+EDPOPREC = Namespace('https://dhstatic.hum.uu.nl/edpop-records/0.1.0/')
 """EDPOP Record Ontology"""
 
 RELATORS = Namespace('http://id.loc.gov/vocabulary/relators/')

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -352,9 +352,11 @@ class DatabaseFileMixin:
                 # some sort of hidden symlink if Python was installed using
                 # the Windows Store...
                 db_dir = self.database_path.parent.resolve()
-                error_message = f'USTC database not found. Please obtain the file ' \
-                                f'{self.DATABASE_FILENAME} from the project team and add it ' \
-                                f'to the following directory: {db_dir}'
+                error_message = (
+                    f'{self.__class__.__name__} database not found. Please obtain the file '
+                    f'{self.DATABASE_FILENAME} from the project team and add it '
+                    f'to the following directory: {db_dir}'
+                )
                 raise ReaderError(error_message)
             else:
                 self._download_database()

--- a/edpop_explorer/readers/dutch_almanacs.py
+++ b/edpop_explorer/readers/dutch_almanacs.py
@@ -1,5 +1,4 @@
 import csv
-from pathlib import Path
 from typing import List
 from edpop_explorer import Reader, ReaderError, Field, BibliographicalRecord, BIBLIOGRAPHICAL, DatabaseFileMixin
 from rdflib import URIRef

--- a/edpop_explorer/readers/dutch_almanacs.py
+++ b/edpop_explorer/readers/dutch_almanacs.py
@@ -22,7 +22,7 @@ class DutchAlmanacsReader(DatabaseFileMixin, Reader):
     def _convert_record(cls, rawrecord: dict) -> BibliographicalRecord:
         record = BibliographicalRecord(from_reader=cls)
         record.data = rawrecord
-        record.identifier = Field(rawrecord['ID'])
+        record.identifier = rawrecord['ID']
         record.dating = Field(rawrecord['Jaar'])
         record.place_of_publication = Field(rawrecord['Plaats uitgave'])
         record.bookseller = Field(rawrecord['Boekverkoper'])

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -14,6 +14,7 @@ from edpop_explorer.sql import SQLPreparedQuery
 
 class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     DATABASE_URL = 'https://dhstatic.hum.uu.nl/edpop/cl.sqlite3'
+    DATABASE_FILENAME = 'cl.sqlite3'
     DATABASE_LICENSE = 'https://dhstatic.hum.uu.nl/edpop/LICENSE.txt'
     FBTEE_LINK = 'http://fbtee.uws.edu.au/stn/interface/browse.php?t=book&' \
         'id={}'
@@ -27,25 +28,22 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     SHORT_NAME = "French Book Trade in Enlightenment Europe (FBTEE)"
     DESCRIPTION = "Mapping the Trade of the Société Typographique de " \
         "Neuchâtel, 1769-1794"
-
-    def __init__(self):
-        super().__init__()
-        self.database_file = Path(
-            AppDirs('edpop-explorer', 'cdh').user_data_dir
-        ) / 'cl.sqlite3'
+    database_path: Path
 
     def prepare_data(self):
-        if not self.database_file.exists():
+        self.database_path = Path(
+            AppDirs('edpop-explorer', 'cdh').user_data_dir
+        ) / 'cl.sqlite3'
+        if not self.database_path.exists():
             self._download_database()
-        self.con = sqlite3.connect(str(self.database_file))
 
     def _download_database(self):
         print('Downloading database...')
         response = requests.get(self.DATABASE_URL)
         if response.ok:
             try:
-                self.database_file.parent.mkdir(exist_ok=True, parents=True)
-                with open(self.database_file, 'wb') as f:
+                self.database_path.parent.mkdir(exist_ok=True, parents=True)
+                with open(self.database_path, 'wb') as f:
                     f.write(response.content)
             except OSError as err:
                 raise ReaderError(
@@ -55,7 +53,7 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             raise ReaderError(
                 f'Error downloading database file from {self.DATABASE_URL}'
             )
-        print(f'Successfully saved database to {self.database_file}.')
+        print(f'Successfully saved database to {self.database_path}.')
         print(f'See license: {self.DATABASE_LICENSE}')
 
     @classmethod
@@ -105,41 +103,42 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             raise ReaderError('First call prepare_query method')
         if self.fetching_exhausted:
             return range(0)
-        cur = self.con.cursor()
-        columns = [x[1] for x in cur.execute('PRAGMA table_info(books)')]
-        res = cur.execute(
-            'SELECT B.*, BA.author_code, A.author_name FROM books B '
-            'LEFT OUTER JOIN books_authors BA on B.book_code=BA.book_code '
-            'JOIN authors A on BA.author_code=A.author_code '
-            f'{self.prepared_query.where_statement} '
-            'ORDER BY B.book_code',
-            self.prepared_query.arguments
-        )
-        last_book_code = ''
-        i = -1
-        for row in res:
-            # Since we are joining with another table, a book may be repeated,
-            # so check if this is a new item
-            book_code: str = row[columns.index('book_code')]
-            if last_book_code != book_code:
-                # We have a new book, so update i
-                i += 1
-                record = BibliographicalRecord(self.__class__)
-                record.data = {}
-                for j in range(len(columns)):
-                    record.data[columns[j]] = row[j]
-                record.identifier = book_code
-                record.link = self.FBTEE_LINK.format(book_code)
-                record.data['authors'] = []
-                self.records[i] = record
-                last_book_code = book_code
-            # Add author_code and author_name to the last record
-            assert len(self.records) > 0
-            author_code = row[len(columns)]
-            author_name = row[len(columns) + 1]
-            assert isinstance(self.records[i].data, dict)
-            self.records[i].data['authors'].append((author_code, author_name))
-        for record in self.records:
-            self._add_fields(record)
-        self.number_of_results = len(self.records)
+        with sqlite3.connect(str(self.database_path)) as con:
+            cur = con.cursor()
+            columns = [x[1] for x in cur.execute('PRAGMA table_info(books)')]
+            res = cur.execute(
+                'SELECT B.*, BA.author_code, A.author_name FROM books B '
+                'LEFT OUTER JOIN books_authors BA on B.book_code=BA.book_code '
+                'JOIN authors A on BA.author_code=A.author_code '
+                f'{self.prepared_query.where_statement} '
+                'ORDER BY B.book_code',
+                self.prepared_query.arguments
+            )
+            last_book_code = ''
+            i = -1
+            for row in res:
+                # Since we are joining with another table, a book may be repeated,
+                # so check if this is a new item
+                book_code: str = row[columns.index('book_code')]
+                if last_book_code != book_code:
+                    # We have a new book, so update i
+                    i += 1
+                    record = BibliographicalRecord(self.__class__)
+                    record.data = {}
+                    for j in range(len(columns)):
+                        record.data[columns[j]] = row[j]
+                    record.identifier = book_code
+                    record.link = self.FBTEE_LINK.format(book_code)
+                    record.data['authors'] = []
+                    self.records[i] = record
+                    last_book_code = book_code
+                # Add author_code and author_name to the last record
+                assert len(self.records) > 0
+                author_code = row[len(columns)]
+                author_name = row[len(columns) + 1]
+                assert isinstance(self.records[i].data, dict)
+                self.records[i].data['authors'].append((author_code, author_name))
+            for record in self.records:
+                self._add_fields(record)
+            self.number_of_results = len(self.records)
         return range(0, len(self.records))

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -1,8 +1,5 @@
-from pathlib import Path
 import sqlite3
 from rdflib import URIRef
-import requests
-from appdirs import AppDirs
 from typing import Optional
 
 from edpop_explorer import (

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -111,7 +111,9 @@ class FBTEEReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
                 author_name = row[len(columns) + 1]
                 assert isinstance(self.records[i].data, dict)
                 self.records[i].data['authors'].append((author_code, author_name))
-            for record in self.records:
+            for record_number in self.records:
+                record = self.records[record_number]
+                assert isinstance(record, BibliographicalRecord)
                 self._add_fields(record)
             self.number_of_results = len(self.records)
         return range(0, len(self.records))

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -6,13 +6,13 @@ from appdirs import AppDirs
 from typing import Optional
 
 from edpop_explorer import (
-    Reader, BibliographicalRecord, ReaderError, Field, BIBLIOGRAPHICAL
+    Reader, BibliographicalRecord, ReaderError, Field, BIBLIOGRAPHICAL, DatabaseFileMixin
 )
 from edpop_explorer.reader import GetByIdBasedOnQueryMixin
 from edpop_explorer.sql import SQLPreparedQuery
 
 
-class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
+class FBTEEReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
     DATABASE_URL = 'https://dhstatic.hum.uu.nl/edpop/cl.sqlite3'
     DATABASE_FILENAME = 'cl.sqlite3'
     DATABASE_LICENSE = 'https://dhstatic.hum.uu.nl/edpop/LICENSE.txt'
@@ -28,33 +28,6 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     SHORT_NAME = "French Book Trade in Enlightenment Europe (FBTEE)"
     DESCRIPTION = "Mapping the Trade of the Société Typographique de " \
         "Neuchâtel, 1769-1794"
-    database_path: Path
-
-    def prepare_data(self):
-        self.database_path = Path(
-            AppDirs('edpop-explorer', 'cdh').user_data_dir
-        ) / 'cl.sqlite3'
-        if not self.database_path.exists():
-            self._download_database()
-
-    def _download_database(self):
-        print('Downloading database...')
-        response = requests.get(self.DATABASE_URL)
-        if response.ok:
-            try:
-                self.database_path.parent.mkdir(exist_ok=True, parents=True)
-                with open(self.database_path, 'wb') as f:
-                    f.write(response.content)
-            except OSError as err:
-                raise ReaderError(
-                    f'Error writing database file to disk: {err}'
-                )
-        else:
-            raise ReaderError(
-                f'Error downloading database file from {self.DATABASE_URL}'
-            )
-        print(f'Successfully saved database to {self.database_path}.')
-        print(f'See license: {self.DATABASE_LICENSE}')
 
     @classmethod
     def _prepare_get_by_id_query(cls, identifier: str) -> SQLPreparedQuery:

--- a/edpop_explorer/readers/kvcs.py
+++ b/edpop_explorer/readers/kvcs.py
@@ -1,13 +1,14 @@
 import csv
 from pathlib import Path
 from typing import List
-from edpop_explorer import Reader, ReaderError, Field, BiographicalRecord, BIOGRAPHICAL
+from edpop_explorer import Reader, ReaderError, Field, BiographicalRecord, BIOGRAPHICAL, DatabaseFileMixin
 from rdflib import URIRef
 
 
-class KVCSReader(Reader):
+class KVCSReader(DatabaseFileMixin, Reader):
     """ KVCS database reader. Access with command 'kvcs'."""
-    FILENAME = Path(__file__).parent / 'data' / 'biblio_kvcs.csv'
+    DATABASE_URL = 'https://dhstatic.hum.uu.nl/edpop/biblio_kvcs.csv'
+    DATABASE_FILENAME = 'biblio_kvcs.csv'
     CATALOG_URIREF = URIRef(
         'https://edpop.hum.uu.nl/readers/kvcs'
     )
@@ -21,7 +22,7 @@ class KVCSReader(Reader):
     def _convert_record(cls, rawrecord: dict) -> BiographicalRecord:
         record = BiographicalRecord(from_reader=cls)
         record.data = rawrecord
-        record.identifier = Field(rawrecord['ID'])
+        record.identifier = rawrecord['ID']
         record.name = Field(rawrecord['Name'])
         record.gender = Field(rawrecord['Gender'])
         record.lifespan = Field(rawrecord['Years of life'])
@@ -37,7 +38,9 @@ class KVCSReader(Reader):
 
     @classmethod
     def get_by_id(cls, identifier: str) -> BiographicalRecord:
-        with open(cls.FILENAME, 'r', encoding='utf-8-sig') as file:
+        reader = cls()
+        reader.prepare_data()
+        with open(reader.database_path, 'r', encoding='utf-8-sig') as file:
             reader = csv.DictReader(file, delimiter=';')
             for row in reader:
                 if row['ID'] == identifier:
@@ -46,10 +49,11 @@ class KVCSReader(Reader):
     
     def _perform_query(self) -> List[BiographicalRecord]:
         assert isinstance(self.prepared_query, str)
+        self.prepare_data()
         
         # Search query in all columns, and fetch results based on query
         results = []
-        with open(self.__class__.FILENAME, 'r', encoding='utf-8-sig') as file:
+        with open(self.database_path, 'r', encoding='utf-8-sig') as file:
             reader = csv.DictReader(file, delimiter=';')
             for row in reader:
                 for key in row.keys():

--- a/edpop_explorer/readers/kvcs.py
+++ b/edpop_explorer/readers/kvcs.py
@@ -1,5 +1,4 @@
 import csv
-from pathlib import Path
 from typing import List
 from edpop_explorer import Reader, ReaderError, Field, BiographicalRecord, BIOGRAPHICAL, DatabaseFileMixin
 from rdflib import URIRef

--- a/edpop_explorer/readers/pierre_belle.py
+++ b/edpop_explorer/readers/pierre_belle.py
@@ -1,5 +1,4 @@
 import csv
-from pathlib import Path
 from typing import List
 from edpop_explorer import Reader, ReaderError, BibliographicalRecord, Field, DatabaseFileMixin
 from rdflib import URIRef

--- a/edpop_explorer/readers/pierre_belle.py
+++ b/edpop_explorer/readers/pierre_belle.py
@@ -1,13 +1,14 @@
 import csv
 from pathlib import Path
 from typing import List
-from edpop_explorer import Reader, ReaderError, BibliographicalRecord, Field
+from edpop_explorer import Reader, ReaderError, BibliographicalRecord, Field, DatabaseFileMixin
 from rdflib import URIRef
 
 
-class PierreBelleReader(Reader):
+class PierreBelleReader(DatabaseFileMixin, Reader):
     """ Pierre-Belle database reader. Access with command 'pb'."""
-    FILENAME = Path(__file__).parent / 'data' / 'biblio_pierrebelle.csv'
+    DATABASE_URL = 'https://dhstatic.hum.uu.nl/edpop/biblio_pierrebelle.csv'
+    DATABASE_FILENAME = 'biblio_pierrebelle.csv'
     CATALOG_URIREF = URIRef(
         'https://edpop.hum.uu.nl/readers/pierre_belle'
     )
@@ -36,7 +37,9 @@ class PierreBelleReader(Reader):
 
     @classmethod
     def get_by_id(cls, identifier: str) -> BibliographicalRecord:
-        with open(cls.FILENAME, 'r', encoding='utf-8-sig') as file:
+        reader = cls()
+        reader.prepare_data()
+        with open(reader.database_path, 'r', encoding='utf-8-sig') as file:
             reader = csv.DictReader(file, delimiter=';')
             for row in reader:
                 if row['ID'] == identifier:
@@ -45,10 +48,11 @@ class PierreBelleReader(Reader):
     
     def _perform_query(self) -> List[BibliographicalRecord]:
         assert isinstance(self.prepared_query, str)
+        self.prepare_data()
         
         # Search query in all columns, and fetch results based on query
         results = []
-        with open(self.__class__.FILENAME, 'r', encoding='utf-8-sig') as file:
+        with open(self.database_path, 'r', encoding='utf-8-sig') as file:
             reader = csv.DictReader(file, delimiter=';')
             for row in reader:
                 for key in row.keys():

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -1,7 +1,5 @@
-from pathlib import Path
 import sqlite3
 from typing import List, Optional, Union
-from appdirs import AppDirs
 from rdflib import URIRef
 
 from edpop_explorer import (

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -24,12 +24,6 @@ class USTCReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
     SHORT_NAME = "Universal Short Title Catalogue (USTC)"
     DESCRIPTION = "An open access bibliography of early modern print culture"
 
-    def __init__(self):
-        super().__init__()
-        self.database_file = Path(
-            AppDirs('edpop-explorer', 'cdh').user_data_dir
-        ) / self.DATABASE_FILENAME
-
     @classmethod
     def transform_query(cls, query: str) -> SQLPreparedQuery:
         where_statement = ( 
@@ -60,7 +54,7 @@ class USTCReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
 
     def fetch_range(self, range_to_fetch: range) -> range:
         self.prepare_data()
-        con = sqlite3.connect(str(self.database_file))
+        con = sqlite3.connect(str(self.database_path))
 
         # This method fetches all records immediately, because the data is
         # locally stored.

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -6,12 +6,12 @@ from rdflib import URIRef
 
 from edpop_explorer import (
     Reader, BibliographicalRecord, ReaderError, Field, BIBLIOGRAPHICAL,
-    GetByIdBasedOnQueryMixin
+    GetByIdBasedOnQueryMixin, DatabaseFileMixin
 )
 from edpop_explorer.sql import SQLPreparedQuery
 
 
-class USTCReader(GetByIdBasedOnQueryMixin, Reader):
+class USTCReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
     DATABASE_FILENAME = 'ustc.sqlite3'
     USTC_LINK = 'https://www.ustc.ac.uk/editions/{}'
     READERTYPE = BIBLIOGRAPHICAL
@@ -29,17 +29,6 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
         self.database_file = Path(
             AppDirs('edpop-explorer', 'cdh').user_data_dir
         ) / self.DATABASE_FILENAME
-
-    def prepare_data(self):
-        if not self.database_file.exists():
-            # Find database dir with .resolve() because on Windows it is
-            # some sort of hidden symlink if Python was installed using
-            # the Windows Store...
-            db_dir = self.database_file.parent.resolve()
-            error_message = f'USTC database not found. Please obtain the file ' \
-                f'{self.DATABASE_FILENAME} from the project team and add it ' \
-                f'to the following directory: {db_dir}'
-            raise ReaderError(error_message)
 
     @classmethod
     def transform_query(cls, query: str) -> SQLPreparedQuery:

--- a/edpop_explorer/record.py
+++ b/edpop_explorer/record.py
@@ -215,7 +215,7 @@ class BibliographicalRecord(Record):
         self._fields += [
             ('title', EDPOPREC.title, Field),
             ('alternative_title', EDPOPREC.alternativeTitle, Field),
-            ('contributors', EDPOPREC.contributors, Field),
+            ('contributors', EDPOPREC.contributor, Field),
             ('publisher_or_printer', EDPOPREC.publisherOrPrinter, Field),
             ('place_of_publication', EDPOPREC.placeOfPublication, Field),
             ('dating', EDPOPREC.dating, Field),


### PR DESCRIPTION
This PR generalizes the way the USTC and FBTEE readers were downloading and using the required database files by outfactoring this functionality and applying it to Dutch Almanacs, KVCS and Pierre Belle too. The databases are downloaded from the dhstatic server.

This PR also includes an update to the README file concerning the installation of database files, as well as a note about the "performing query" message in the Explorer CLI.

Update: also refer to a specific version of the EDPOP record ontology, close #25 