### PR TITLE
Add "digitization" field to bibliographical records and implement it for Gallica

### DIFF
--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -1,6 +1,6 @@
 __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
-    'Field', 'FieldError', 'LocationField',
+    'Field', 'FieldError', 'LocationField', 'DigitizationField',
     'Reader', 'ReaderError', 'NotFoundError',
     'GetByIdBasedOnQueryMixin', 'DatabaseFileMixin',
     'BasePreparedQuery', 'PreparedQueryType',
@@ -18,7 +18,7 @@ BIBLIOGRAPHICAL = "bibliographical"
 BIOGRAPHICAL = "biographical"
 
 from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
-from .fields import Field, FieldError, LocationField
+from .fields import Field, FieldError, LocationField, DigitizationField
 from .reader import (
     Reader, ReaderError, GetByIdBasedOnQueryMixin, BasePreparedQuery,
     PreparedQueryType, NotFoundError, DatabaseFileMixin

--- a/edpop_explorer/fields.py
+++ b/edpop_explorer/fields.py
@@ -207,3 +207,30 @@ class ContributorField(Field):
         else:
             return name
 
+
+class DigitizationField(Field):
+    _rdf_class = EDPOPREC.DigitizationField
+    description: Optional[str] = None
+    url: Optional[str] = None
+    iiif_manifest: Optional[str] = None
+    preview_url: Optional[str] = None
+
+    def __init__(self, original_text: str) -> None:
+        super().__init__(original_text)
+        self._subfields.extend((
+            ('description', EDPOPREC.description, 'string'),
+            ('url', EDPOPREC.url, 'string'),
+            ('iiif_manifest', EDPOPREC.iiifManifest, 'string'),
+            ('preview_url', EDPOPREC.previewURL, 'string'),
+        ))
+
+    @property
+    def summary_text(self) -> Optional[str]:
+        if self.description is not None:
+            return self.description
+        elif self.iiif_manifest is not None:
+            return self.iiif_manifest
+        elif self.url is not None:
+            return self.url
+        else:
+            return self.original_text

--- a/edpop_explorer/record.py
+++ b/edpop_explorer/record.py
@@ -4,7 +4,8 @@ from rdflib.term import Node
 from rdflib import URIRef, Graph, BNode, RDF, Literal
 
 from edpop_explorer import (
-    EDPOPREC, Field, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces
+    EDPOPREC, Field, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces,
+    DigitizationField
 )
 
 if TYPE_CHECKING:
@@ -221,6 +222,7 @@ class BibliographicalRecord(Record):
     genres: Optional[List[Field]] = None
     holdings: Optional[List[Field]] = None
     typographical_features: Optional[List[Field]] = None
+    digitization: Optional[List[Field]] = None
 
     def __init__(self, from_reader: Type["Reader"]):
         super().__init__(from_reader)
@@ -244,6 +246,7 @@ class BibliographicalRecord(Record):
             ('genres', EDPOPREC.genre, Field),
             ('holdings', EDPOPREC.holdings, Field),
             ('typographical_features', EDPOPREC.typographicalFeatures, Field),
+            ('digitization', EDPOPREC.digitization, DigitizationField),
         ]
 
     def __str__(self) -> str:


### PR DESCRIPTION
To add information about digitizations to bibliographical records, I created `DigitizationField` which can hold a IIIF manifest or, if not available, a URL that the user can visit to access the digitization. In this pull request, I only implemented it for the Gallica reader.

The `DigitizationField` also contains the subfields `description` (to make distinction between different digitizations, which is relevant for STCN), and `previewURL`, which can hold the URL of an image that allows for a quick preview of the digitization (in the case of IIIF, this is not needed because a thumbnail is part of the IIIF manifest).