### PR TITLE
Fixes for KBReader

### DIFF
--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -21,7 +21,7 @@ def get_extent_type(input_string: str) -> ExtentType:
 
 
 def get_extent_like_fields(data: dict, type_: ExtentType) -> List[Field]:
-    if not KBReader.EXTENT_LOCATION in data:
+    if KBReader.EXTENT_LOCATION not in data:
         return []
     if isinstance(data[KBReader.EXTENT_LOCATION], list):
         extent = data[KBReader.EXTENT_LOCATION]


### PR DESCRIPTION
Some fixes to partially address the problems in #87:

- There were some problems with the way the "extent" field was converted. These are fixed: the contents of this field will now go to the extent, size or bibliographical format field.
- The dating field is now also extracted
- The record IDs are now correctly recorded
- There was a problem with the SRU URL: it stopped working and I changed it to a different URL which is according to the documentation.