### PR TITLE
Allow PPN numbers ending in X

### DIFF
--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -66,7 +66,7 @@ class KBReader(SRUReader):
         record_identifier = data.get('http://krait.kb.nl/coop/tel/handbook/telterms.html:recordIdentifier', None)
         if isinstance(record_identifier, str):
             # Record identifier is an URL that should end with PPN=<PPN>. The start of the URL is variable.
-            match = re.match(r'^.*PPN=(\d+)$', record_identifier)
+            match = re.match(r'^.*PPN=(\d+X?)$', record_identifier)
             if match:
                 return match.group(1)
         return None

--- a/tests/readers/test_kb.py
+++ b/tests/readers/test_kb.py
@@ -1,0 +1,27 @@
+from edpop_explorer.readers.kb import KBReader
+
+record_identifier_key = 'http://krait.kb.nl/coop/tel/handbook/telterms.html:recordIdentifier'
+
+
+def test_find_ppn_ri_picarta():
+    data = {
+        record_identifier_key: 'http://picarta.pica.nl/DB=2.4/PPN?PPN=306044579'
+    }
+    reader = KBReader()
+    assert reader._find_ppn(data) == '306044579'
+
+
+def test_find_ppn_ri_picarta_with_x():
+    data = {
+        record_identifier_key: 'http://picarta.pica.nl/DB=2.4/PPN?PPN=28961774X'
+    }
+    reader = KBReader()
+    assert reader._find_ppn(data) == '28961774X'
+
+
+def test_find_ppn_ri_oclc():
+    data = {
+        record_identifier_key: 'https://opc-kb.oclc.org/DB=1/PPN?PPN=238713652'
+    }
+    reader = KBReader()
+    assert reader._find_ppn(data) == '238713652'


### PR DESCRIPTION
Apparently there was still a problem after merging #92 - some PPN numbers end in an X (like old ISBNs)... Here is a fix together with some tests.