### PR TITLE
Add ALLOW_EMPTY_QUERY and MAXIMUM_RECORDS_PER_PAGE attributes

### DIFF
--- a/edpop_explorer/cerl.py
+++ b/edpop_explorer/cerl.py
@@ -24,6 +24,7 @@ class CERLReader(GetByIdBasedOnQueryMixin, Reader):
     """The base URL for userfriendly representations of single records."""
     additional_params: Optional[Dict[str, str]] = None
     DEFAULT_RECORDS_PER_PAGE = 10
+    MAXIMUM_RECORDS_PER_PAGE = 100
 
     @classmethod
     def _prepare_get_by_id_query(cls, identifier: str) -> str:

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -78,6 +78,12 @@ class Reader(ABC):
     _fetch_position: int = 0
     """The index of the record that was fetched last. This is used by
     the ``fetch()`` method to decide where to continue fetching."""
+    MAXIMUM_RECORDS_PER_PAGE: Optional[int] = None
+    """Maximum number of records to fetch per page. If not set, there
+    is no predefined limit."""
+    ALLOW_EMPTY_QUERY = False
+    """If True, it is possible to enter an empty query to fetch all
+    records."""
 
     def __init__(self):
         self.records = {}
@@ -233,6 +239,11 @@ class Reader(ABC):
             g.add((cls.CATALOG_URIREF, SDO.description, Literal(cls.DESCRIPTION)))
         if (slug := cls.get_catalog_slug()) is not None:
             g.add((cls.CATALOG_URIREF, SDO.identifier, Literal(slug)))
+
+        # Add additional properties
+        if cls.MAXIMUM_RECORDS_PER_PAGE:
+            g.add((cls.CATALOG_URIREF, EDPOPREC.maximumRecordsPerPage, Literal(cls.MAXIMUM_RECORDS_PER_PAGE)))
+        g.add((cls.CATALOG_URIREF, EDPOPREC.allowEmptyQuery, Literal(cls.ALLOW_EMPTY_QUERY)))
 
         # Set namespace prefixes
         bind_common_namespaces(g)

--- a/edpop_explorer/readers/dutch_almanacs.py
+++ b/edpop_explorer/readers/dutch_almanacs.py
@@ -16,6 +16,7 @@ class DutchAlmanacsReader(DatabaseFileMixin, Reader):
     SHORT_NAME = "Dutch Almanacs"
     DESCRIPTION = "Bibliography of Dutch Almanacs 1570-1710"
     READERTYPE = BIBLIOGRAPHICAL
+    ALLOW_EMPTY_QUERY = True
 
     @classmethod
     def _convert_record(cls, rawrecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/kvcs.py
+++ b/edpop_explorer/readers/kvcs.py
@@ -16,6 +16,7 @@ class KVCSReader(DatabaseFileMixin, Reader):
     SHORT_NAME = "KVCS"
     DESCRIPTION = "Drukkers & Uitgevers in KVCS"
     READERTYPE = BIOGRAPHICAL
+    ALLOW_EMPTY_QUERY = True
 
     @classmethod
     def _convert_record(cls, rawrecord: dict) -> BiographicalRecord:

--- a/edpop_explorer/readers/pierre_belle.py
+++ b/edpop_explorer/readers/pierre_belle.py
@@ -19,6 +19,7 @@ class PierreBelleReader(DatabaseFileMixin, Reader):
     SHORT_NAME = "Pierre and Belle"
     DESCRIPTION = "Bibliography of early modern editions of Pierre de " \
         "Provence et la Belle Maguelonne (ca. 1470-ca. 1800)"
+    ALLOW_EMPTY_QUERY = True
 
     @classmethod
     def _convert_record(cls, rawrecord: dict) -> BibliographicalRecord:

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -21,6 +21,7 @@ class USTCReader(DatabaseFileMixin, GetByIdBasedOnQueryMixin, Reader):
     prepared_query: Optional[SQLPreparedQuery] = None
     SHORT_NAME = "Universal Short Title Catalogue (USTC)"
     DESCRIPTION = "An open access bibliography of early modern print culture"
+    ALLOW_EMPTY_QUERY = True
 
     @classmethod
     def transform_query(cls, query: str) -> SQLPreparedQuery:


### PR DESCRIPTION
Add ALLOW_EMPTY_QUERY and MAXIMUM_RECORDS_PER_PAGE attributes, which are useful for the VRE.

These changes are necessary for https://github.com/CentreForDigitalHumanities/EDPOP/pull/345.