### PR TITLE
Various fixes for edpop-explorer

### DIFF
--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -5,15 +5,18 @@ from edpop_explorer import SRUReader, BibliographicalRecord, BIBLIOGRAPHICAL
 from edpop_explorer import Field
 from edpop_explorer.fields import LanguageField, ContributorField
 
-ExtentType = Literal['extent', 'size', 'bibliographical-format']
+ExtentType = Literal['extent', 'size', 'bibliographical-format', 'collation-formula']
 
 
 def get_extent_type(input_string: str) -> ExtentType:
     # KB's 'extent' field is broader than ours: it may also contain the
-    # bibliographical format or the size.
+    # bibliographical format, the size or the collation formula.
     # If it is of the format in-<number>, assume bibliographical format.
+    # If it starts with 'A' or '[A]', assume collation formula.
     if re.match(r'^in-\d+$', input_string):
         return 'bibliographical-format'
+    elif input_string.startswith('A') or input_string.startswith('[A]'):
+        return 'collation-formula'
     elif input_string.endswith(' cm'):
         return 'size'
     else:
@@ -82,6 +85,7 @@ class KBReader(SRUReader):
         record.extent = get_extent_like_fields(sruthirecord, 'extent')
         record.size = get_extent_like_fields(sruthirecord, 'size')
         record.bibliographical_format = get_extent_like_fields(sruthirecord, 'bibliographical-format')
+        record.collation_formula = get_extent_like_fields(sruthirecord, 'collation-formula')
         record.publisher_or_printer = self._get_publisher(sruthirecord)
         record.contributors = self._get_contributors(sruthirecord)
         record.dating = self._get_dating(sruthirecord)

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -145,8 +145,9 @@ class VD18Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
             return list(filter(None, map(holding_from_marc21_vd18, holdings_fields)))
         else:
             # If holding not available, try to get the holding institution through the Redaktion field instead
-            holding_inst = data.get_first_subfield('850', 'a').removeprefix('RedVD18-')
-            if holding_inst:
+            holding_inst_subfield = data.get_first_subfield('850', 'a')
+            if holding_inst_subfield:
+                holding_inst = holding_inst_subfield.removeprefix('RedVD18-')
                 try:
                     institution_name = get_isil_name_by_code(holding_inst)
                 except HTTPError:

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -16,6 +16,9 @@ def holding_from_marc21_vd17(field: Marc21Field) -> Optional[Field]:
         institution = get_isil_name_by_code(f"DE-{institution_code}") if institution_code else None
     except HTTPError:
         institution = institution_code
+    # Try once more with subfield f, which sometimes contains the institution name
+    if not institution:
+        institution = field.subfields.get('f')
     shelf_mark = field.subfields.get('a')
     return format_holding(institution, shelf_mark)
 


### PR DESCRIPTION
This PR fixes some important problems, pointed out by Jeroen, and relevant for the demonstration:

- Avoid a server error in VD18 for certain queries
- Adjust VD17Reader so that it finds much more institution names for holdings (but still not all)
- Put the collation formula in KBReader in the correct field

I fixed the other main problem (the absence of the USTC database file) on the server.